### PR TITLE
Fix AllowGroups configuration

### DIFF
--- a/templates/sshd_config.j2
+++ b/templates/sshd_config.j2
@@ -117,7 +117,7 @@ UsePAM yes
 {% endif %}
 
 {% if sshd__restrict_groups -%}
-  AllowUsers {{ sshd__allowed_groups|join(' ') }}
+  AllowGroups {{ sshd__allowed_groups|join(' ') }}
 {%- endif %}
 
 # Allow client to pass locale environment variables


### PR DESCRIPTION
The config template currently generates two `AllowUsers` directives. The second one is meant to be `AllowGroups`.