### PR TITLE
Fix sftp subsystem for Archlinux

### DIFF
--- a/templates/sshd_config.j2
+++ b/templates/sshd_config.j2
@@ -125,6 +125,8 @@ AcceptEnv LANG LC_*
 # Subsystem sftp /usr/lib/openssh/sftp-server
 {% if ansible_os_family == 'RedHat' %}
 Subsystem sftp /usr/libexec/openssh/sftp-server
+{% elif ansible_os_family == 'Archlinux' %}
+Subsystem sftp /usr/lib/ssh/sftp-server
 {% else %}
 Subsystem sftp /usr/lib/openssh/sftp-server
 {% endif %}


### PR DESCRIPTION
On Archlinux hosts, sftp path is `/usr/lib/ssh/sftp-server`.

Without this fix, trying to `scp` files to an Archlinux SSH server fails with error: `scp: connection closed`.

Solves #8